### PR TITLE
RGBA出力の対応

### DIFF
--- a/ffmpegOut/encode/auo_convert.cpp
+++ b/ffmpegOut/encode/auo_convert.cpp
@@ -108,6 +108,9 @@ static const COVERT_FUNC_INFO FUNC_TABLE[] = {
     //Copy RGB
     { CF_RGB,  OUT_CSP_RGB,    BIT_8, A,  1,  SSE2,                 copy_rgb_sse2 },
     { CF_RGB,  OUT_CSP_RGB,    BIT_8, A,  1,  NONE,                 copy_rgb },
+    //Copy RGBA
+    { CF_RGBA,  OUT_CSP_RGBA,  BIT_8, A,  1,  SSE2,                 copy_rgba_sse2 },
+    { CF_RGBA,  OUT_CSP_RGBA,  BIT_8, A,  1,  NONE,                 copy_rgba },
 
     //YUY2 -> nv12(8bit)
     { CF_YUY2, OUT_CSP_NV12,   BIT_8, P,  1,  AVX2,                 convert_yuy2_to_nv12_avx2 },
@@ -169,6 +172,11 @@ static void auo_write_func_info(const COVERT_FUNC_INFO *func_info) {
 
     if (func_info->output_csp == OUT_CSP_RGB) {
         write_log_auo_line_fmt(LOG_INFO, "Copying RGB%s", simd_buf);
+        return;
+    }
+
+    if (func_info->output_csp == OUT_CSP_RGBA) {
+        write_log_auo_line_fmt(LOG_INFO, "Copying RGBA%s", simd_buf);
         return;
     }
 
@@ -254,6 +262,10 @@ BOOL malloc_pixel_data(CONVERT_CF_DATA * const pixel_data, int width, int height
             break;
         case OUT_CSP_RGB:
             if ((pixel_data->data[0] = (BYTE *)_mm_malloc(frame_size * 3, max(align_size, 16))) == NULL)
+                ret = FALSE;
+            break;
+        case OUT_CSP_RGBA:
+            if ((pixel_data->data[0] = (BYTE*)_mm_malloc(frame_size * 4, max(align_size, 16))) == NULL)
                 ret = FALSE;
             break;
         case OUT_CSP_NV12:

--- a/ffmpegOut/encode/auo_encode.cpp
+++ b/ffmpegOut/encode/auo_encode.cpp
@@ -69,6 +69,7 @@ BOOL check_output(CONF_GUIEX *conf, const OUTPUT_INFO *oip, const PRM_ENC *pe, c
     switch (conf->enc.output_csp) {
         case OUT_CSP_YUV444:
         case OUT_CSP_RGB:
+        case OUT_CSP_RGBA:
             w_mul = 1, h_mul = 1; break;
         case OUT_CSP_NV16:
             w_mul = 2, h_mul = 1; break;

--- a/ffmpegOut/encode/auo_video.h
+++ b/ffmpegOut/encode/auo_video.h
@@ -37,18 +37,41 @@ typedef struct {
     DWORD size;  //1ピクセルあたりバイト数
 } COLORFORMAT_DATA;
 
+typedef struct {
+    unsigned char b, g, r, a;
+} PixelBGRA;
+
+typedef struct {
+    int frame_start;
+    int frame_end;
+    int width;
+    int height;
+    int rate;
+    int scale;
+} ExeditData;
+
+typedef struct {
+    BOOL(*output_start)(ExeditData* data);
+    void(*output_end)();
+    PixelBGRA* (*get_image)(int frame);
+} ExeditFileMapping;
+
 enum {
     CF_YUY2 = 0,
     CF_YC48 = 1,
     CF_RGB  = 2,
+    CF_RGBA = 3,
 };
-static const char * const CF_NAME[] = { "YUY2", "YC48", "RGB" };
+static const char * const CF_NAME[] = { "YUY2", "YC48", "RGB", "RGBA"};
 static const COLORFORMAT_DATA COLORFORMATS[] = {
     { MAKEFOURCC('Y', 'U', 'Y', '2'), 2 }, //YUY2
     { MAKEFOURCC('Y', 'C', '4', '8'), 6 }, //YC48
-    { NULL,                           3 }  //RGB
+    { NULL,                           3 }, //RGB
+    { NULL,                           3 }  //RGBA(Unused)
 };
 
 AUO_RESULT video_output(CONF_GUIEX *conf, const OUTPUT_INFO *oip, PRM_ENC *pe, const SYSTEM_DATA *sys_dat);
+
+static BOOL get_exedit_file_mapping(ExeditFileMapping* efm);
 
 #endif //_AUO_VIDEO_H_

--- a/ffmpegOut/encode/convert.cpp
+++ b/ffmpegOut/encode/convert.cpp
@@ -236,7 +236,7 @@ void copy_rgba(void* frame, CONVERT_CF_DATA* pixel_data, const int width, const 
     BYTE* ptr = pixel_data->data[0];
     BYTE* dst, * src;
     int y0 = 0, y1 = height - 1;
-    const int step = (width * 4 + 4) & ~4;
+    const int step = width * 4;
     for (; y0 < height; y0++, y1--) {
         dst = ptr + y1 * width * 4;
         src = (BYTE*)frame + y0 * step;
@@ -249,7 +249,7 @@ void copy_rgba_sse2(void* frame, CONVERT_CF_DATA* pixel_data, const int width, c
     BYTE* dst, * src, * src_fin;
     __m128i x0, x1, x2, x3;
     int y0 = 0, y1 = height - 1;
-    const int step = (width * 4 + 4) & ~4;
+    const int step = width * 4;
     const int y_fin = height - 1;
     for (; y0 < y_fin; y0++, y1--) {
         dst = ptr + y0 * width * 4;

--- a/ffmpegOut/encode/convert.cpp
+++ b/ffmpegOut/encode/convert.cpp
@@ -231,6 +231,59 @@ void sort_to_rgb(void *frame, CONVERT_CF_DATA *pixel_data, const int width, cons
     }
 }
 
+
+void copy_rgba(void* frame, CONVERT_CF_DATA* pixel_data, const int width, const int height) {
+    BYTE* ptr = pixel_data->data[0];
+    BYTE* dst, * src;
+    int y0 = 0, y1 = height - 1;
+    const int step = (width * 4 + 4) & ~4;
+    for (; y0 < height; y0++, y1--) {
+        dst = ptr + y1 * width * 4;
+        src = (BYTE*)frame + y0 * step;
+        for (int x = 0; x < width * 4; x++)
+            dst[x] = src[x];
+    }
+}
+void copy_rgba_sse2(void* frame, CONVERT_CF_DATA* pixel_data, const int width, const int height) {
+    BYTE* ptr = pixel_data->data[0];
+    BYTE* dst, * src, * src_fin;
+    __m128i x0, x1, x2, x3;
+    int y0 = 0, y1 = height - 1;
+    const int step = (width * 4 + 4) & ~4;
+    const int y_fin = height - 1;
+    for (; y0 < y_fin; y0++, y1--) {
+        dst = ptr + y0 * width * 4;
+        src = (BYTE*)frame + y1 * step;
+        src_fin = src + width * 4;
+        for (; src < src_fin; src += 64, dst += 64) {
+            x0 = _mm_loadu_si128((const __m128i*)(src + 0));
+            x1 = _mm_loadu_si128((const __m128i*)(src + 16));
+            x2 = _mm_loadu_si128((const __m128i*)(src + 32));
+            x3 = _mm_loadu_si128((const __m128i*)(src + 48));
+            _mm_storeu_si128((__m128i*)(dst + 0), x0);
+            _mm_storeu_si128((__m128i*)(dst + 16), x1);
+            _mm_storeu_si128((__m128i*)(dst + 32), x2);
+            _mm_storeu_si128((__m128i*)(dst + 48), x3);
+        }
+    }
+    dst = ptr + y0 * width * 4;
+    src = (BYTE*)frame + y1 * step;
+    src_fin = src + ((width * 4) & ~63);
+    for (; src < src_fin; src += 64, dst += 64) {
+        x0 = _mm_loadu_si128((const __m128i*)(src + 0));
+        x1 = _mm_loadu_si128((const __m128i*)(src + 16));
+        x2 = _mm_loadu_si128((const __m128i*)(src + 32));
+        x3 = _mm_loadu_si128((const __m128i*)(src + 48));
+        _mm_storeu_si128((__m128i*)(dst + 0), x0);
+        _mm_storeu_si128((__m128i*)(dst + 16), x1);
+        _mm_storeu_si128((__m128i*)(dst + 32), x2);
+        _mm_storeu_si128((__m128i*)(dst + 48), x3);
+    }
+    src_fin = src + ((width * 4) & 63);
+    for (; src < src_fin; src++, dst++)
+        *dst = *src;
+}
+
 void convert_yuy2_to_yv12(void *frame, CONVERT_CF_DATA *pixel_data, const int width, const int height) {
     int x, y;
     BYTE *Y  = pixel_data->data[0];

--- a/ffmpegOut/encode/convert.h
+++ b/ffmpegOut/encode/convert.h
@@ -75,6 +75,8 @@ void copy_rgb_sse2(void *frame, CONVERT_CF_DATA *pixel_data, const int width, co
 void sort_to_rgb(void *frame, CONVERT_CF_DATA *pixel_data, const int width, const int height);
 void sort_to_rgb_ssse3(void *frame, CONVERT_CF_DATA *pixel_data, const int width, const int height);
 
+void copy_rgba(void* frame, CONVERT_CF_DATA* pixel_data, const int width, const int height);
+void copy_rgba_sse2(void* frame, CONVERT_CF_DATA* pixel_data, const int width, const int height);
 
 
 //YUY2 -> nv12 (8bit)

--- a/ffmpegOut/frm/auo_error.cpp
+++ b/ffmpegOut/frm/auo_error.cpp
@@ -430,3 +430,12 @@ void warning_failed_open_bat_orig() {
 void warning_failed_open_bat_new() {
     write_log_auo_line(LOG_WARNING, "一時バッチファイルを作成できませんでした。");
 }
+
+
+void error_get_exedit_file_mapping() {
+    write_log_auo_line_fmt(LOG_ERROR, "拡張編集が見つかりませんでした。");
+}
+
+void error_get_exedit_output_start() {
+    write_log_auo_line_fmt(LOG_ERROR, "拡張編集での出力開始に失敗しました。");
+}

--- a/ffmpegOut/frm/auo_error.h
+++ b/ffmpegOut/frm/auo_error.h
@@ -103,4 +103,7 @@ void warning_malloc_batfile_tmp();
 void warning_failed_open_bat_orig();
 void warning_failed_open_bat_new();
 
+void error_get_exedit_file_mapping();
+void error_get_exedit_output_start();
+
 #endif //_AUO_ERROR_H_

--- a/ffmpegOut/prm/auo_options.h
+++ b/ffmpegOut/prm/auo_options.h
@@ -66,6 +66,7 @@ enum {
     OUT_CSP_P010,
     OUT_CSP_YUV444_16,
     OUT_CSP_RGB,
+    OUT_CSP_RGBA,
     OUT_CSP_NV16,
 };
 
@@ -83,7 +84,8 @@ static const char * const specify_csp[] = {
     "yuv444p", //OUT_CSP_YUV444
     "p010le",
     "yuv444p16le",
-    "bgr24"    //OUT_CSP_RGB
+    "bgr24",   //OUT_CSP_RGB
+    "bgra"     //OUT_CSP_RGBA
 };
 //文字列を引数にとるオプションの引数リスト
 //OUT_CSP_NV12, OUT_CSP_YUV444, OUT_CSP_RGB に合わせる
@@ -94,6 +96,7 @@ const X264_OPTION_STR list_output_csp[] = {
     { "p010le",      L"yuv420(16bit)" },
     { "yuv444p16le", L"yuv444(16bit)" },
     { "bgr24",   L"rgb"  },
+    { "bgra",   L"rgba"  },
     { NULL, NULL }
 };
 
@@ -101,6 +104,7 @@ static bool csp_highbit_depth(int output_csp) {
     static const bool list[] = {
         false, false, false,
         true, true,
+        false,
         false,
         false /*dummy*/
     };


### PR DESCRIPTION
[こちらの記事](https://scrapbox.io/ePi5131/%E3%82%A2%E3%83%AB%E3%83%95%E3%82%A1%E6%83%85%E5%A0%B1%E4%BB%98%E3%81%8D%E5%87%BA%E5%8A%9B%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%E3%82%92%E4%BD%9C%E3%82%8B%E3%81%AB%E3%81%AF)をもとに、ffmpegOutをRGBA出力に対応させてみました。